### PR TITLE
Revisions to support Zkill redisq

### DIFF
--- a/rqtest.py
+++ b/rqtest.py
@@ -1,0 +1,74 @@
+import os, threading, sys, sqlite3
+
+import eveapi
+import zkbapi
+import fleetapi
+# import slackapi
+# import recruitment
+import yaml
+import os
+import logging
+from time import gmtime, strftime
+
+# config = yaml.load(file('plugins/stats/statsbot.conf', 'r'))
+# token = config["SLACK_TOKEN"]
+
+# api_client = slackapi.init(token)
+
+#logging.basicConfig(filename='/tmp/statsbot.log', level=logging.INFO)
+
+outputs = []
+crontable = []
+
+#poll for new kills every 10minutes
+#crontable.append([600, "autokill"])
+#poll for new recruits every 1minutes
+# crontable.append([60, "autorec"])
+#poll for members approaching the end of their trial, every 24hours
+# crontable.append([86400, "autotrial"])
+#poll for new members in the last 24 hours
+#crontable.append([86400, "autonew"])
+
+killChannelId = "C04MCGR8Y"
+testChannelId = "C04N5P17B"
+recruitChannelId = "G04NGUDHF"
+generalChannelId = "C04L6NKQ3"
+
+
+
+def autokill():
+	logging.info("autokill: polling for new kills")
+	#grab the lastKillId from sqlite
+#	dir_path = os.path.dirname(os.path.abspath(__file__))
+#	con = sqlite3.connect(os.path.join(dir_path, 'statsbot.db'))
+
+	if 1:	# Just to avoid fixing indents from here down
+#	with con:
+#		cur = con.cursor()
+#		cur.execute('select id from lastkillid')
+
+#		lastKillId = str(cur.fetchone()[0])
+		lastKillId = 0
+		kills = zkbapi.getNewKills(lastKillId)
+
+		for kill in kills:
+			if kill == "error":
+				continue
+#			kill = kill.encode('utf-8')
+			logging.info(kill)
+			logging.info('1')
+#			logging.info(kill['killID'])
+			logging.info(type(kill))
+			logging.info('2')
+			killIdInt = str(kill['killID'])
+			print "Kill: ", killIdInt
+			print zkbapi.parseKill(kill)
+#			outputs.append([killChannelId, zkbapi.parseKill(kill)])
+#			logging.info("autokill: updating latest kill to " + killIdInt)
+
+#			cur.execute('update lastkillid set id = '+killIdInt)
+#			con.commit()
+
+print zkbapi.getLastKill()
+
+autokill()

--- a/zkbapi.py
+++ b/zkbapi.py
@@ -13,20 +13,122 @@ killid = 0
 allianceId = "99006319"
 headers = {'user-agent': 'WiNGSPAN Slack webhook (all kill tracker 10min poll) feabell@gmail.com'}
 
-def getNewKills(lastKillId):
-	global headers
-	data = ""
-	url = 'https://zkillboard.com/api/kills/alliance/' + allianceId +  '/no-items/afterKillID/' + lastKillId + '/orderDirection/asc/';
 
-	try:
-		data = json.loads(requests.get(url, headers=headers).text)
-	except:
-		logging.info("could not connect to zkb")
+def getNewKills(ignore):
+
+# Don't need the arguement anymore, so we ignore it if it's passed
+
+
+	global headers, allianceId
+
+	kill = ""
+	killmail = ""
+	pkg = ""
+	attkrs = ""
+	alliance = ""
+	allId = ""
+	data = []
+
+#	URL to use RedisQ on zkill to get killmails. 
+#	- ttw param specifies the wait time - the server will return an empty result
+#	  if there no new kills arrive in ttw seconds (default is 10)
+#	- queueID parameter provides a string to the server to track kills sent. Default
+#	  is to use the client IP address. Server will only send kills it hasn't already sent
+#	  (going back 3 hours)
+	url = 'https://redisq.zkillboard.com/listen.php?ttw=1&queueID=WDS9906319'
+
+#	To prevent a runaway loop for pulling kills. Server sends just one kill per request
+#	so we loop to get all available, up to this maximum
+	safety = 101
+
+
+	for n in range(1, safety):
+		try:
+			pkg =  json.loads(requests.get(url, headers=headers).text)
+		except:
+			logging.info("could not connect to zkb")
+			break
+
+		killmail = pkg['package']
+
+#		RedisQ/Readme.md on github says "null" is returned if there are no
+#		new kills available, but it appears that it's "None" 
+		if str(killmail) == "None":
+			break
+
+		kill = killmail['killmail']
+
+#		Select kills where Wingspan alliance is among the attackers
+		attkrs = kill['attackers']
+		for atkr in attkrs:
+			if 'alliance' in atkr:
+				alliance = atkr['alliance']
+
+#				There are odd cases where there is no "id_str" for an alliance
+				if 'id_str' in alliance:
+					allId = alliance['id_str']
+					if allId == allianceId:
+						data.append( killmail )
+						break
 
 	return data
+
 		
 
-def parseKill(kill):
+# Parse the killmail format as provided by redisq.zkillboard.com
+def parseKill(killmail):
+	kill = killmail['killmail']
+	killIdInt = kill['killID']
+	v = kill['victim']
+		
+	#grab the primary attacker as the pilot in the attackers array with the finalBlow attribute set
+	a = filter(checkFinalBlow,kill['attackers'])[0]
+		
+	#grab stuff from the kill json blob
+	#generic info
+	system = "unknown"
+	if 'solarSystem' in kill:
+		if 'name' in kill['solarSystem']:
+			system = kill['solarSystem']['name']
+		else:
+			if 'id_str' in kill['solarSystem']:
+				system = eveapi.getSystem(str(kill['solarSystem']['id_str']))
+	killurl = "https://zkillboard.com/kill/"+str(killIdInt)+"/"	
+	shipvalue = str(round(killmail['zkb']['totalValue']/1000000, 2))
+	killtime = kill['killTime']
+	pilotcount = str(len(kill['attackers']) - 1)
+
+	#victim info
+	victim = "unknown"
+	if 'character' in v:
+		if 'name' in v['character']:
+			victim = v['character']['name']
+	corp = "unknown"
+	if 'corporation' in v:
+		if 'name' in v['corporation']:
+			corp = v['corporation']['name']
+#	alliance = v['allianceName']
+	ship = "unknown"
+	if 'shipType' in v:
+		if 'name' in v['shipType']:
+			ship = v['shipType']['name']
+		else:
+			if 'id_str' in v['shipType']:
+				ship = eveapi.getShip(str(v['shipType']['id_str']))
+		
+	#attacker info
+	pilot = "unknown"
+	if 'character' in a:
+		if 'name' in a['character']:
+			pilot = a['character']['name']
+
+	message = victim +"("+ corp +") lost their "+ ship +" worth "+ shipvalue +"m to "+ pilot +"(and "+ pilotcount + " others) in "+ system +" at "+ killtime +". "+ killurl 
+	
+	return message
+
+
+# parse the kiallmail format as provided by zkillboard.com/api/kills
+def parseKillZkApi(kill):
 	killIdInt = kill['killID']
 	v = kill['victim']
 		
@@ -55,6 +157,7 @@ def parseKill(kill):
 	return message
 
 
+
 def getLastKill():
 	global toSlack
 	global killid
@@ -72,7 +175,7 @@ def getLastKill():
 		killidint = blob['killID']
 		if (killidint > killid):
 			killid = killidint
-			toSlack = parseKill(blob)
+			toSlack = parseKillZkApi(blob)
 	
 		logging.info("lastkill: responded for killid " + str(killidint))
 	except Exception as e:


### PR DESCRIPTION
I've recoded zkbapi.py to support RedisQ.  Here's a quick summary:
- recoded getNewKills() to get the latest kills from RedisQ until there are no more new ones or a safety maximum is reached
--- the safety maximum is set at 101, but that should likely be optimized with the crontable entry for autokill() in statsbot.py
- filtered kms in getNewKills() to include only those that have an attacker in the Wingspan alliance
- RedisQ uses a different killmail format than zkillboard.com/api  so I created a second parseKill function, one for each format
- changed call to parseKill() in getLastKill() to call the original (renamed) parse function
- no changes needed for the calling functions in statsbot.py

Tested on Ubuntu with Python 2.7.6. Tested with a test driver derived from statsbot.py.  Not integration tested with logging and outputs objects.

The lastkillid in statsbot.db is redundant now. RedisQ keeps track of the last kms collected by each client so saving lastkillid is not longer required. getNewKills accepts but ignores the lastkillid argument.

I also added rqtest.py - simply a test driver for the changes in zkbapi.py. 